### PR TITLE
Update pct.Rmd

### DIFF
--- a/vignettes/pct.Rmd
+++ b/vignettes/pct.Rmd
@@ -109,9 +109,9 @@ There are other `get_()` functions that get official data underlying the PCT, as
 For now, let's see how the functions work.
 To get the centroids in Isle of Wight, you would run:
 
-```{r, eval=FALSE}
+```{r, eval=TRUE}
 library(pct)
-wight_centroids = get_pct_centroids(region = "isle-of-wight")
+wight_centroids = get_pct_centroids(region = "isle-of-wight", geography = "msoa")
 wight_zones = get_pct_zones(region = "isle-of-wight")
 ```
 


### PR DESCRIPTION
Fix for issue 79 (PCT vignettes not reproducible)
- added geography label as MSOA to sort the mismatch between fetching centroid data.
- Switched EVAL = FALSE to TRUE.